### PR TITLE
feat: add local config template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Compiled Lua sources
 luac.out
 
+# Per-machine Neovim settings
+local.lua
+
 # luarocks build files
 *.src.rock
 *.zip
@@ -38,4 +41,3 @@ luac.out
 *.i*86
 *.x86_64
 *.hex
-

--- a/init.lua
+++ b/init.lua
@@ -21,6 +21,10 @@ for _, required in ipairs(required_local_values) do
 	end
 end
 
+if vim.g.cf_tool ~= "codex" and vim.g.cf_tool ~= "claude" then
+	error('local.lua must set vim.g.cf_tool to "codex" or "claude"')
+end
+
 require("options")
 require("keymaps_general")
 require("keymaps_ai")

--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,26 @@
+local config_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
+local local_config = config_root .. "/local.lua"
+
+if vim.fn.filereadable(local_config) ~= 1 then
+	error("Missing local.lua. Copy local.lua.example to local.lua and edit per machine.")
+end
+
+dofile(local_config)
+
+local required_local_values = {
+	{ name = "cf_tool", kind = "string" },
+	{ name = "cf_timeout_ms", kind = "number" },
+	{ name = "obsidian_path", kind = "string" },
+	{ name = "supermaven_enabled", kind = "boolean" },
+}
+
+for _, required in ipairs(required_local_values) do
+	local value = vim.g[required.name]
+	if type(value) ~= required.kind then
+		error("local.lua must set vim.g." .. required.name .. " as " .. required.kind)
+	end
+end
+
 require("options")
 require("keymaps_general")
 require("keymaps_ai")

--- a/local.lua.example
+++ b/local.lua.example
@@ -1,0 +1,4 @@
+vim.g.cf_tool = "codex" -- "codex" or "claude"
+vim.g.cf_timeout_ms = 15 * 60 * 1000
+vim.g.obsidian_path = "~/Obsidian/"
+vim.g.supermaven_enabled = false

--- a/local.lua.example
+++ b/local.lua.example
@@ -2,3 +2,8 @@ vim.g.cf_tool = "codex" -- "codex" or "claude"
 vim.g.cf_timeout_ms = 15 * 60 * 1000
 vim.g.obsidian_path = "~/Obsidian/"
 vim.g.supermaven_enabled = false
+
+local node_host_prog = vim.fn.exepath("neovim-node-host")
+if node_host_prog ~= "" then
+	vim.g.node_host_prog = node_host_prog
+end

--- a/lua/llm_jobs.lua
+++ b/lua/llm_jobs.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local timeout_ms = 15 * 60 * 1000
+local timeout_ms = vim.g.cf_timeout_ms
 local log_dir = vim.fn.stdpath("cache") .. "/llm-exec"
 local jobs_dir = log_dir .. "/jobs"
 local jobs = {}
@@ -10,9 +10,10 @@ local max_log_files = 100
 local list_state = nil
 
 local function current_tool()
-	local tool = vim.g.cf_tool or "codex"
+	local tool = vim.g.cf_tool
 	if tool ~= "codex" and tool ~= "claude" then
-		return "codex"
+		vim.notify("Invalid vim.g.cf_tool: " .. tostring(tool), vim.log.levels.ERROR)
+		return nil
 	end
 	return tool
 end
@@ -636,6 +637,9 @@ function M.run(location, snippet, message, bufnr)
 	local root = repo_root(file)
 	local prompt = build_prompt(location, snippet, message)
 	local tool = current_tool()
+	if not tool then
+		return
+	end
 	local cmd, cmd_err = build_command(tool, root, prompt)
 	if not cmd then
 		vim.notify(cmd_err, vim.log.levels.ERROR)

--- a/lua/plugins/ai.lua
+++ b/lua/plugins/ai.lua
@@ -7,65 +7,37 @@ return {
 			},
 		},
 	},
-	-- {
-	-- 	"supermaven-inc/supermaven-nvim",
-	-- 	config = function()
-	-- 		require("supermaven-nvim").setup({
-	-- 			keymaps = {
-	-- 				accept_suggestion = "<S-Tab>",
-	-- 				accept_word = "<C-w>",
-	-- 				clear_suggestion = "<C-e>",
-	-- 			},
-	-- 		})
-	--
-	-- 		local api = require("supermaven-nvim.api")
-	-- 		vim.api.nvim_create_autocmd("VimEnter", {
-	-- 			callback = function()
-	-- 				vim.defer_fn(function()
-	-- 					api.start()
-	-- 					print("se")
-	-- 				end, 100)
-	-- 			end,
-	-- 		})
-	--
-	-- 		vim.keymap.set("n", "<leader>sm", function()
-	-- 			if api.is_running() then
-	-- 				api.stop()
-	-- 				print("sd")
-	-- 			else
-	-- 				api.start()
-	-- 				print("se")
-	-- 			end
-	-- 		end, { desc = "Toggle SM" })
-	-- 	end,
-	-- },
-	-- {
-	--   "zbirenbaum/copilot.lua",
-	--   cmd = "Copilot",
-	--   event = "InsertEnter",
-	--   config = function()
-	--     require("copilot").setup({
-	--       suggestion = {
-	--         enabled = true,
-	--         auto_trigger = true,
-	--         keymap = {
-	--           accept = "<S-Tab>",
-	--           accept_word = "<C-w>",
-	--           accept_line = "<C-y>",
-	--           dismiss = "<C-e>",
-	--           next = "<C-n>",
-	--           prev = "<C-p>",
-	--         },
-	--       },
-	--       panel = { enabled = false },
-	--     })
-	--
-	--     vim.g.copilot_enabled = true
-	--     vim.keymap.set("n", "<leader>ta", function()
-	--       require("copilot.suggestion").toggle_auto_trigger()
-	--       vim.g.copilot_enabled = not vim.g.copilot_enabled
-	--       print(vim.g.copilot_enabled and "AI on" or "AI off")
-	--     end, { desc = "Toggle Copilot" })
-	--   end,
-	-- },
+	{
+		"supermaven-inc/supermaven-nvim",
+		enabled = vim.g.supermaven_enabled == true,
+		config = function()
+			require("supermaven-nvim").setup({
+				keymaps = {
+					accept_suggestion = "<S-Tab>",
+					accept_word = "<C-w>",
+					clear_suggestion = "<C-e>",
+				},
+			})
+
+			local api = require("supermaven-nvim.api")
+			vim.api.nvim_create_autocmd("VimEnter", {
+				callback = function()
+					vim.defer_fn(function()
+						api.start()
+						print("se")
+					end, 100)
+				end,
+			})
+
+			vim.keymap.set("n", "<leader>sm", function()
+				if api.is_running() then
+					api.stop()
+					print("sd")
+				else
+					api.start()
+					print("se")
+				end
+			end, { desc = "Toggle SM" })
+		end,
+	},
 }

--- a/lua/plugins/ai.lua
+++ b/lua/plugins/ai.lua
@@ -24,7 +24,6 @@ return {
 				callback = function()
 					vim.defer_fn(function()
 						api.start()
-						print("se")
 					end, 100)
 				end,
 			})
@@ -32,10 +31,10 @@ return {
 			vim.keymap.set("n", "<leader>sm", function()
 				if api.is_running() then
 					api.stop()
-					print("sd")
+					vim.notify("Supermaven disabled")
 				else
 					api.start()
-					print("se")
+					vim.notify("Supermaven enabled")
 				end
 			end, { desc = "Toggle SM" })
 		end,

--- a/lua/plugins/obsidian.lua
+++ b/lua/plugins/obsidian.lua
@@ -10,7 +10,7 @@ return {
 	-- 	workspaces = {
 	-- 		{
 	-- 			name = "personal",
-	-- 			path = "~/Obsidian/",
+	-- 			path = vim.g.obsidian_path,
 	-- 		},
 	-- 	},
 	-- },


### PR DESCRIPTION
### Problem
Machine-specific Neovim settings are currently either hardcoded or commented directly in tracked config, which creates conflict risk across computers.

### Changes
- Add required repo-root `local.lua` loading from `init.lua`.
- Add committed `local.lua.example` with defaults for `cf_tool`, `cf_timeout_ms`, `obsidian_path`, and `supermaven_enabled`.
- Gitignore the real per-machine `local.lua`.
- Make `<leader>cf` require `vim.g.cf_tool` from local config and validate it is `codex` or `claude`.
- Make the LLM job timeout configurable via `vim.g.cf_timeout_ms`.
- Add an optional `vim.g.node_host_prog` default from system `neovim-node-host` discovery when available.
- Wire Supermaven as an enabled plugin spec controlled by `vim.g.supermaven_enabled`, defaulting off in the example.
- Keep Obsidian commented out, but change the commented path to reference `vim.g.obsidian_path` when it is eventually enabled.
- Delete the old commented Copilot plugin block.
- Replace opaque Supermaven status prints with clearer notifications and remove the startup debug print.

### Decisions
- `local.lua` is required, not optional, so each machine declares its local settings explicitly.
- Obsidian remains disabled/commented out.
- The Node provider setting is optional: if `neovim-node-host` is not discoverable, the example leaves `vim.g.node_host_prog` unset so Neovim can use normal system discovery.

### Testing
- Created ignored `local.lua` from `local.lua.example`.
- Loaded Neovim headlessly with this repo init file and verified `cf_tool`, `cf_timeout_ms`, `obsidian_path`, `supermaven_enabled`, and mapping setup.
- Verified missing `local.lua` raises the intended startup error.
- Ran `git diff --check`.

<details>
<summary>Agent Context</summary>

Ar wants a repo-root `local.lua` pattern that acts like a `.env` equivalent for Neovim Lua config. The real `local.lua` should be per-machine and gitignored; `local.lua.example` should be committed with his defaults. Requested settings are `cf_tool = "codex"` with `claude` known as the alternate, the existing Obsidian file location from the commented plugin config, and `supermaven_enabled = false`. Ar later clarified that among additional obvious configurables, only the LLM job timeout is worthwhile, so this PR also includes `cf_timeout_ms`. He also asked for the work-machine Node path case to be represented without hardcoding a local path; this PR adds an optional system-discovered `vim.g.node_host_prog` block at the end of `local.lua.example`. Supermaven had been commented out; this PR comments the plugin spec back in but keeps it disabled unless the local boolean is true. Obsidian must remain commented out for now; this PR only changes the commented path line so it points at `vim.g.obsidian_path` when enabled later. The old commented Copilot plugin block was dead config and has been deleted.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine-specific configuration support for tool selection, workspace path, timeout, and plugin preference.
  * Supermaven integration enabled with a toggle keybinding and automatic startup initialization.
* **Bug Fixes**
  * Validation with user-facing errors for missing/invalid configuration.
  * Prevents AI tasks from starting when the selected tool is invalid.
* **Chores**
  * Updated ignore rules for local settings and added an example configuration file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryan-binazir/neovim-config/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->