### PR TITLE
refactor: clean up LLM keymaps and jobs

### DIFF
--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -239,7 +239,7 @@ local function toggle_ai_split(cmd)
 		"#{pane_id}",
 		"-c",
 		vim.fn.getcwd(),
-		"$SHELL -ic " .. cmd,
+		"$SHELL -ic " .. vim.fn.shellescape(cmd),
 	})
 	pane_id = vim.trim(pane_id)
 	if pane_id == "" then
@@ -251,9 +251,13 @@ local function toggle_ai_split(cmd)
 end
 
 for _, mapping in ipairs({
-	{ lhs = "<leader>cc", cmd = "accd", desc = "Open Claude Code in tmux split" },
-	{ lhs = "<leader>cd", cmd = "acdd", desc = "Open Codex in tmux split" },
-	{ lhs = "<leader>co", cmd = "aco", desc = "Open OpenCode in tmux split" },
+	{ lhs = "<leader>cc", cmd = "claude --dangerously-skip-permissions", desc = "Open Claude Code in tmux split" },
+	{
+		lhs = "<leader>cd",
+		cmd = "codex --dangerously-bypass-approvals-and-sandbox",
+		desc = "Open Codex in tmux split",
+	},
+	{ lhs = "<leader>co", cmd = "opencode", desc = "Open OpenCode in tmux split" },
 }) do
 	local lhs, cmd, desc = mapping.lhs, mapping.cmd, mapping.desc
 	vim.keymap.set("n", lhs, function()

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -228,19 +228,13 @@ local function toggle_ai_split(cmd)
 		close_ai_pane()
 		return
 	end
-	local pane_id = vim.fn.system({
-		"tmux",
-		"split-window",
-		"-h",
-		"-p",
-		"35",
-		"-P",
-		"-F",
-		"#{pane_id}",
-		"-c",
-		vim.fn.getcwd(),
-		"$SHELL -ic " .. cmd,
-	})
+	local pane_id = vim.fn.system(
+		'tmux split-window -h -p 35 -P -F "#{pane_id}" -c '
+			.. vim.fn.shellescape(vim.fn.getcwd())
+			.. " '$SHELL -ic "
+			.. cmd
+			.. "'"
+	)
 	pane_id = vim.trim(pane_id)
 	if pane_id == "" then
 		print("Failed to create tmux split")

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -230,13 +230,19 @@ local function toggle_ai_split(cmd)
 		close_ai_pane()
 		return
 	end
-	local pane_id = vim.fn.system(
-		'tmux split-window -h -p 35 -P -F "#{pane_id}" -c '
-			.. vim.fn.shellescape(vim.fn.getcwd())
-			.. " '$SHELL -ic "
-			.. cmd
-			.. "'"
-	)
+	local pane_id = vim.fn.system({
+		"tmux",
+		"split-window",
+		"-h",
+		"-p",
+		"35",
+		"-P",
+		"-F",
+		"#{pane_id}",
+		"-c",
+		vim.fn.getcwd(),
+		"$SHELL -ic " .. cmd,
+	})
 	pane_id = vim.trim(pane_id)
 	if pane_id == "" then
 		print("Failed to create tmux split")

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -228,19 +228,12 @@ local function toggle_ai_split(cmd)
 		close_ai_pane()
 		return
 	end
-	local pane_id = vim.fn.system({
-		"tmux",
-		"split-window",
-		"-h",
-		"-p",
-		"35",
-		"-P",
-		"-F",
-		"#{pane_id}",
-		"-c",
-		vim.fn.getcwd(),
-		"$SHELL -ic " .. vim.fn.shellescape(cmd),
-	})
+	local pane_id = vim.fn.system(
+		'tmux split-window -h -p 35 -P -F "#{pane_id}" -c '
+			.. vim.fn.shellescape(vim.fn.getcwd())
+			.. " "
+			.. vim.fn.shellescape("$SHELL -ic " .. vim.fn.shellescape(cmd))
+	)
 	pane_id = vim.trim(pane_id)
 	if pane_id == "" then
 		print("Failed to create tmux split")

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -11,14 +11,53 @@ local function format_range(start_line, end_line)
 	return start_line == end_line and tostring(start_line) or (start_line .. "-" .. end_line)
 end
 
+local function visual_range()
+	local start_line = vim.fn.line("v")
+	local end_line = vim.fn.line(".")
+	if start_line > end_line then
+		start_line, end_line = end_line, start_line
+	end
+	return start_line, end_line
+end
+
+local function feed_escape()
+	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+end
+
+local function current_file_or_notify()
+	local file = vim.fn.expand("%:p")
+	if file == "" then
+		vim.notify("Current buffer has no file name", vim.log.levels.ERROR)
+		return nil
+	end
+	return file
+end
+
+local function optional_require(name, label)
+	local ok, module = pcall(require, name)
+	if not ok then
+		print(label .. " not available")
+		return nil
+	end
+	return module
+end
+
+local function ai_pane_target()
+	if not vim.g.ai_pane_id then
+		return nil
+	end
+	return vim.fn.shellescape(vim.g.ai_pane_id)
+end
+
 -- Helper for sending to AI pane
 local function send_to_ai_pane(text, focus)
-	if not vim.g.ai_pane_id then
+	local target = ai_pane_target()
+	if not target then
 		return
 	end
-	vim.fn.system("tmux send-keys -t " .. vim.fn.shellescape(vim.g.ai_pane_id) .. " -l " .. vim.fn.shellescape(text))
+	vim.fn.system("tmux send-keys -t " .. target .. " -l " .. vim.fn.shellescape(text))
 	if focus then
-		vim.fn.system("tmux select-pane -t " .. vim.fn.shellescape(vim.g.ai_pane_id))
+		vim.fn.system("tmux select-pane -t " .. target)
 	end
 end
 
@@ -43,9 +82,8 @@ end, { desc = "Yank all buffer paths" })
 
 -- Yank all harpoon paths
 vim.keymap.set("n", "<leader>yh", function()
-	local ok, harpoon = pcall(require, "harpoon")
-	if not ok then
-		print("Harpoon not available")
+	local harpoon = optional_require("harpoon", "Harpoon")
+	if not harpoon then
 		return
 	end
 	local paths = {}
@@ -63,11 +101,7 @@ end, { desc = "Yank all harpoon paths" })
 local yank_ns = vim.api.nvim_create_namespace("yank_selection_highlight")
 
 local function yank_selection(include_code, skip_register)
-	local start_line = vim.fn.line("v")
-	local end_line = vim.fn.line(".")
-	if start_line > end_line then
-		start_line, end_line = end_line, start_line
-	end
+	local start_line, end_line = visual_range()
 	local bufnr = vim.api.nvim_get_current_buf()
 	local path = vim.fn.expand("%:p")
 	local result = path .. ":" .. format_range(start_line, end_line)
@@ -78,7 +112,7 @@ local function yank_selection(include_code, skip_register)
 	if not skip_register then
 		vim.fn.setreg("+", result)
 	end
-	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+	feed_escape()
 	-- Highlight the yanked range
 	vim.defer_fn(function()
 		vim.highlight.range(bufnr, yank_ns, "IncSearch", { start_line - 1, 0 }, { end_line - 1, -1 })
@@ -112,12 +146,11 @@ local function tmux_available()
 end
 
 local function ai_pane_alive()
-	if not vim.g.ai_pane_id then
+	local target = ai_pane_target()
+	if not target then
 		return false
 	end
-	local check = vim.fn.system(
-		"tmux display-message -t " .. vim.fn.shellescape(vim.g.ai_pane_id) .. " -p '#{pane_id}' 2>/dev/null"
-	)
+	local check = vim.fn.system("tmux display-message -t " .. target .. " -p '#{pane_id}' 2>/dev/null")
 	return vim.trim(check) ~= ""
 end
 
@@ -141,6 +174,15 @@ local function mark_ai_pane(pane_id, cmd)
 	tmux_set_pane_option(pane_id, ai_pane_cmd_option, cmd)
 end
 
+local function close_ai_pane()
+	local target = ai_pane_target()
+	if target then
+		vim.fn.system("tmux kill-pane -t " .. target)
+	end
+	vim.g.ai_pane_id = nil
+	print("AI pane closed")
+end
+
 local ensure_ai_pane
 
 -- Send selection to AI pane
@@ -159,9 +201,8 @@ end, { desc = "Send selection to AI pane" })
 
 -- Yank all file paths in Oil directory
 vim.keymap.set("n", "<leader>yo", function()
-	local ok, oil = pcall(require, "oil")
-	if not ok then
-		print("Oil not available")
+	local oil = optional_require("oil", "Oil")
+	if not oil then
 		return
 	end
 	local dir = oil.get_current_dir()
@@ -186,9 +227,7 @@ local function toggle_ai_split(cmd)
 		return
 	end
 	if ensure_ai_pane() then
-		vim.fn.system("tmux kill-pane -t " .. vim.fn.shellescape(vim.g.ai_pane_id))
-		vim.g.ai_pane_id = nil
-		print("AI pane closed")
+		close_ai_pane()
 		return
 	end
 	local pane_id = vim.fn.system(
@@ -207,17 +246,16 @@ local function toggle_ai_split(cmd)
 	vim.g.ai_pane_id = pane_id
 end
 
-vim.keymap.set("n", "<leader>cc", function()
-	toggle_ai_split("accd")
-end, { desc = "Open Claude Code in tmux split" })
-
-vim.keymap.set("n", "<leader>cd", function()
-	toggle_ai_split("acdd")
-end, { desc = "Open Codex in tmux split" })
-
-vim.keymap.set("n", "<leader>co", function()
-	toggle_ai_split("aco")
-end, { desc = "Open OpenCode in tmux split" })
+for _, mapping in ipairs({
+	{ lhs = "<leader>cc", cmd = "accd", desc = "Open Claude Code in tmux split" },
+	{ lhs = "<leader>cd", cmd = "acdd", desc = "Open Codex in tmux split" },
+	{ lhs = "<leader>co", cmd = "aco", desc = "Open OpenCode in tmux split" },
+}) do
+	local lhs, cmd, desc = mapping.lhs, mapping.cmd, mapping.desc
+	vim.keymap.set("n", lhs, function()
+		toggle_ai_split(cmd)
+	end, { desc = desc })
+end
 
 vim.keymap.set("n", "<leader>cp", function()
 	if ensure_ai_pane() then
@@ -229,9 +267,7 @@ end, { desc = "Send file path to AI pane" })
 
 vim.keymap.set("n", "<leader>cq", function()
 	if ensure_ai_pane() then
-		vim.fn.system("tmux kill-pane -t " .. vim.fn.shellescape(vim.g.ai_pane_id))
-		vim.g.ai_pane_id = nil
-		print("AI pane closed")
+		close_ai_pane()
 	else
 		print("No AI pane open")
 	end
@@ -294,9 +330,8 @@ vim.keymap.set("n", "<leader>cl", llm_jobs.open_list, { desc = "Open LLM job lis
 -- Quick scoped message: runs a one-shot editor task through cf_tool.
 vim.keymap.set("n", "<leader>cf", function()
 	local bufnr = vim.api.nvim_get_current_buf()
-	local file = vim.fn.expand("%:p")
-	if file == "" then
-		vim.notify("Current buffer has no file name", vim.log.levels.ERROR)
+	local file = current_file_or_notify()
+	if not file then
 		return
 	end
 	local line, snippet = cf_current_line_snippet()
@@ -311,19 +346,14 @@ end, { desc = "Run scoped LLM fix" })
 -- Visual mode: scoped message with line range
 vim.keymap.set("v", "<leader>cf", function()
 	local bufnr = vim.api.nvim_get_current_buf()
-	local start_line = vim.fn.line("v")
-	local end_line = vim.fn.line(".")
-	if start_line > end_line then
-		start_line, end_line = end_line, start_line
-	end
-	local file = vim.fn.expand("%:p")
-	if file == "" then
-		vim.notify("Current buffer has no file name", vim.log.levels.ERROR)
-		vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+	local start_line, end_line = visual_range()
+	local file = current_file_or_notify()
+	if not file then
+		feed_escape()
 		return
 	end
 	local range = format_range(start_line, end_line)
-	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+	feed_escape()
 
 	vim.schedule(function()
 		local message = vim.fn.input("LLM Message: ")

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -228,13 +228,19 @@ local function toggle_ai_split(cmd)
 		close_ai_pane()
 		return
 	end
-	local pane_id = vim.fn.system(
-		'tmux split-window -h -p 35 -P -F "#{pane_id}" -c '
-			.. vim.fn.shellescape(vim.fn.getcwd())
-			.. " '$SHELL -ic "
-			.. cmd
-			.. "'"
-	)
+	local pane_id = vim.fn.system({
+		"tmux",
+		"split-window",
+		"-h",
+		"-p",
+		"35",
+		"-P",
+		"-F",
+		"#{pane_id}",
+		"-c",
+		vim.fn.getcwd(),
+		"$SHELL -ic " .. cmd,
+	})
 	pane_id = vim.trim(pane_id)
 	if pane_id == "" then
 		print("Failed to create tmux split")

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -11,14 +11,53 @@ local function format_range(start_line, end_line)
 	return start_line == end_line and tostring(start_line) or (start_line .. "-" .. end_line)
 end
 
+local function visual_range()
+	local start_line = vim.fn.line("v")
+	local end_line = vim.fn.line(".")
+	if start_line > end_line then
+		start_line, end_line = end_line, start_line
+	end
+	return start_line, end_line
+end
+
+local function feed_escape()
+	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+end
+
+local function current_file_or_notify()
+	local file = vim.fn.expand("%:p")
+	if file == "" then
+		vim.notify("Current buffer has no file name", vim.log.levels.ERROR)
+		return nil
+	end
+	return file
+end
+
+local function optional_require(name, label)
+	local ok, module = pcall(require, name)
+	if not ok then
+		print(label .. " not available")
+		return nil
+	end
+	return module
+end
+
+local function ai_pane_target()
+	if not vim.g.ai_pane_id then
+		return nil
+	end
+	return vim.fn.shellescape(vim.g.ai_pane_id)
+end
+
 -- Helper for sending to AI pane
 local function send_to_ai_pane(text, focus)
-	if not vim.g.ai_pane_id then
+	local target = ai_pane_target()
+	if not target then
 		return
 	end
-	vim.fn.system("tmux send-keys -t " .. vim.fn.shellescape(vim.g.ai_pane_id) .. " -l " .. vim.fn.shellescape(text))
+	vim.fn.system("tmux send-keys -t " .. target .. " -l " .. vim.fn.shellescape(text))
 	if focus then
-		vim.fn.system("tmux select-pane -t " .. vim.fn.shellescape(vim.g.ai_pane_id))
+		vim.fn.system("tmux select-pane -t " .. target)
 	end
 end
 
@@ -43,9 +82,8 @@ end, { desc = "Yank all buffer paths" })
 
 -- Yank all harpoon paths
 vim.keymap.set("n", "<leader>yh", function()
-	local ok, harpoon = pcall(require, "harpoon")
-	if not ok then
-		print("Harpoon not available")
+	local harpoon = optional_require("harpoon", "Harpoon")
+	if not harpoon then
 		return
 	end
 	local paths = {}
@@ -63,11 +101,7 @@ end, { desc = "Yank all harpoon paths" })
 local yank_ns = vim.api.nvim_create_namespace("yank_selection_highlight")
 
 local function yank_selection(include_code, skip_register)
-	local start_line = vim.fn.line("v")
-	local end_line = vim.fn.line(".")
-	if start_line > end_line then
-		start_line, end_line = end_line, start_line
-	end
+	local start_line, end_line = visual_range()
 	local bufnr = vim.api.nvim_get_current_buf()
 	local path = vim.fn.expand("%:p")
 	local result = path .. ":" .. format_range(start_line, end_line)
@@ -78,7 +112,7 @@ local function yank_selection(include_code, skip_register)
 	if not skip_register then
 		vim.fn.setreg("+", result)
 	end
-	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+	feed_escape()
 	-- Highlight the yanked range
 	vim.defer_fn(function()
 		vim.highlight.range(bufnr, yank_ns, "IncSearch", { start_line - 1, 0 }, { end_line - 1, -1 })
@@ -105,19 +139,17 @@ end, { desc = "Yank file path, lines, and code (full lines)" })
 -- AI tools in tmux splits
 vim.g.ai_pane_id = nil
 local ai_pane_marker = "@nvim_ai_pane"
-local ai_pane_cmd_option = "@nvim_ai_cmd"
 
 local function tmux_available()
 	return vim.fn.executable("tmux") == 1
 end
 
 local function ai_pane_alive()
-	if not vim.g.ai_pane_id then
+	local target = ai_pane_target()
+	if not target then
 		return false
 	end
-	local check = vim.fn.system(
-		"tmux display-message -t " .. vim.fn.shellescape(vim.g.ai_pane_id) .. " -p '#{pane_id}' 2>/dev/null"
-	)
+	local check = vim.fn.system("tmux display-message -t " .. target .. " -p '#{pane_id}' 2>/dev/null")
 	return vim.trim(check) ~= ""
 end
 
@@ -133,12 +165,20 @@ local function tmux_set_pane_option(pane_id, option, value)
 	)
 end
 
-local function mark_ai_pane(pane_id, cmd)
+local function mark_ai_pane(pane_id)
 	if not pane_id or pane_id == "" then
 		return
 	end
 	tmux_set_pane_option(pane_id, ai_pane_marker, "1")
-	tmux_set_pane_option(pane_id, ai_pane_cmd_option, cmd)
+end
+
+local function close_ai_pane()
+	local target = ai_pane_target()
+	if target then
+		vim.fn.system("tmux kill-pane -t " .. target)
+	end
+	vim.g.ai_pane_id = nil
+	print("AI pane closed")
 end
 
 local ensure_ai_pane
@@ -159,9 +199,8 @@ end, { desc = "Send selection to AI pane" })
 
 -- Yank all file paths in Oil directory
 vim.keymap.set("n", "<leader>yo", function()
-	local ok, oil = pcall(require, "oil")
-	if not ok then
-		print("Oil not available")
+	local oil = optional_require("oil", "Oil")
+	if not oil then
 		return
 	end
 	local dir = oil.get_current_dir()
@@ -186,9 +225,7 @@ local function toggle_ai_split(cmd)
 		return
 	end
 	if ensure_ai_pane() then
-		vim.fn.system("tmux kill-pane -t " .. vim.fn.shellescape(vim.g.ai_pane_id))
-		vim.g.ai_pane_id = nil
-		print("AI pane closed")
+		close_ai_pane()
 		return
 	end
 	local pane_id = vim.fn.system(
@@ -203,21 +240,20 @@ local function toggle_ai_split(cmd)
 		print("Failed to create tmux split")
 		return
 	end
-	mark_ai_pane(pane_id, cmd)
+	mark_ai_pane(pane_id)
 	vim.g.ai_pane_id = pane_id
 end
 
-vim.keymap.set("n", "<leader>cc", function()
-	toggle_ai_split("accd")
-end, { desc = "Open Claude Code in tmux split" })
-
-vim.keymap.set("n", "<leader>cd", function()
-	toggle_ai_split("acdd")
-end, { desc = "Open Codex in tmux split" })
-
-vim.keymap.set("n", "<leader>co", function()
-	toggle_ai_split("aco")
-end, { desc = "Open OpenCode in tmux split" })
+for _, mapping in ipairs({
+	{ lhs = "<leader>cc", cmd = "accd", desc = "Open Claude Code in tmux split" },
+	{ lhs = "<leader>cd", cmd = "acdd", desc = "Open Codex in tmux split" },
+	{ lhs = "<leader>co", cmd = "aco", desc = "Open OpenCode in tmux split" },
+}) do
+	local lhs, cmd, desc = mapping.lhs, mapping.cmd, mapping.desc
+	vim.keymap.set("n", lhs, function()
+		toggle_ai_split(cmd)
+	end, { desc = desc })
+end
 
 vim.keymap.set("n", "<leader>cp", function()
 	if ensure_ai_pane() then
@@ -229,16 +265,14 @@ end, { desc = "Send file path to AI pane" })
 
 vim.keymap.set("n", "<leader>cq", function()
 	if ensure_ai_pane() then
-		vim.fn.system("tmux kill-pane -t " .. vim.fn.shellescape(vim.g.ai_pane_id))
-		vim.g.ai_pane_id = nil
-		print("AI pane closed")
+		close_ai_pane()
 	else
 		print("No AI pane open")
 	end
 end, { desc = "Close AI pane" })
 
 -- Find a pane this config marked, so it survives nvim closing and reopening.
-local function find_ai_pane_in_window()
+local function find_marked_ai_pane()
 	local out = vim.fn.system('tmux list-panes -F "#{pane_id}\t#{@nvim_ai_pane}" 2>/dev/null')
 	if vim.v.shell_error ~= 0 then
 		return nil
@@ -257,7 +291,7 @@ ensure_ai_pane = function()
 		return true
 	end
 
-	local existing = find_ai_pane_in_window()
+	local existing = find_marked_ai_pane()
 	if existing then
 		vim.g.ai_pane_id = existing
 		return true
@@ -294,9 +328,8 @@ vim.keymap.set("n", "<leader>cl", llm_jobs.open_list, { desc = "Open LLM job lis
 -- Quick scoped message: runs a one-shot editor task through cf_tool.
 vim.keymap.set("n", "<leader>cf", function()
 	local bufnr = vim.api.nvim_get_current_buf()
-	local file = vim.fn.expand("%:p")
-	if file == "" then
-		vim.notify("Current buffer has no file name", vim.log.levels.ERROR)
+	local file = current_file_or_notify()
+	if not file then
 		return
 	end
 	local line, snippet = cf_current_line_snippet()
@@ -311,19 +344,14 @@ end, { desc = "Run scoped LLM fix" })
 -- Visual mode: scoped message with line range
 vim.keymap.set("v", "<leader>cf", function()
 	local bufnr = vim.api.nvim_get_current_buf()
-	local start_line = vim.fn.line("v")
-	local end_line = vim.fn.line(".")
-	if start_line > end_line then
-		start_line, end_line = end_line, start_line
-	end
-	local file = vim.fn.expand("%:p")
-	if file == "" then
-		vim.notify("Current buffer has no file name", vim.log.levels.ERROR)
-		vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+	local start_line, end_line = visual_range()
+	local file = current_file_or_notify()
+	if not file then
+		feed_escape()
 		return
 	end
 	local range = format_range(start_line, end_line)
-	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+	feed_escape()
 
 	vim.schedule(function()
 		local message = vim.fn.input("LLM Message: ")

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -229,7 +229,7 @@ local function toggle_ai_split(cmd)
 		return
 	end
 	local pane_id = vim.fn.system(
-		'tmux split-window -h -p 35 -P -F "#{pane_id}" -c '
+		'tmux split-window -h -l 35% -P -F "#{pane_id}" -c '
 			.. vim.fn.shellescape(vim.fn.getcwd())
 			.. " "
 			.. vim.fn.shellescape("$SHELL -ic " .. vim.fn.shellescape(cmd))

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -11,53 +11,14 @@ local function format_range(start_line, end_line)
 	return start_line == end_line and tostring(start_line) or (start_line .. "-" .. end_line)
 end
 
-local function visual_range()
-	local start_line = vim.fn.line("v")
-	local end_line = vim.fn.line(".")
-	if start_line > end_line then
-		start_line, end_line = end_line, start_line
-	end
-	return start_line, end_line
-end
-
-local function feed_escape()
-	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
-end
-
-local function current_file_or_notify()
-	local file = vim.fn.expand("%:p")
-	if file == "" then
-		vim.notify("Current buffer has no file name", vim.log.levels.ERROR)
-		return nil
-	end
-	return file
-end
-
-local function optional_require(name, label)
-	local ok, module = pcall(require, name)
-	if not ok then
-		print(label .. " not available")
-		return nil
-	end
-	return module
-end
-
-local function ai_pane_target()
-	if not vim.g.ai_pane_id then
-		return nil
-	end
-	return vim.fn.shellescape(vim.g.ai_pane_id)
-end
-
 -- Helper for sending to AI pane
 local function send_to_ai_pane(text, focus)
-	local target = ai_pane_target()
-	if not target then
+	if not vim.g.ai_pane_id then
 		return
 	end
-	vim.fn.system("tmux send-keys -t " .. target .. " -l " .. vim.fn.shellescape(text))
+	vim.fn.system("tmux send-keys -t " .. vim.fn.shellescape(vim.g.ai_pane_id) .. " -l " .. vim.fn.shellescape(text))
 	if focus then
-		vim.fn.system("tmux select-pane -t " .. target)
+		vim.fn.system("tmux select-pane -t " .. vim.fn.shellescape(vim.g.ai_pane_id))
 	end
 end
 
@@ -82,8 +43,9 @@ end, { desc = "Yank all buffer paths" })
 
 -- Yank all harpoon paths
 vim.keymap.set("n", "<leader>yh", function()
-	local harpoon = optional_require("harpoon", "Harpoon")
-	if not harpoon then
+	local ok, harpoon = pcall(require, "harpoon")
+	if not ok then
+		print("Harpoon not available")
 		return
 	end
 	local paths = {}
@@ -101,7 +63,11 @@ end, { desc = "Yank all harpoon paths" })
 local yank_ns = vim.api.nvim_create_namespace("yank_selection_highlight")
 
 local function yank_selection(include_code, skip_register)
-	local start_line, end_line = visual_range()
+	local start_line = vim.fn.line("v")
+	local end_line = vim.fn.line(".")
+	if start_line > end_line then
+		start_line, end_line = end_line, start_line
+	end
 	local bufnr = vim.api.nvim_get_current_buf()
 	local path = vim.fn.expand("%:p")
 	local result = path .. ":" .. format_range(start_line, end_line)
@@ -112,7 +78,7 @@ local function yank_selection(include_code, skip_register)
 	if not skip_register then
 		vim.fn.setreg("+", result)
 	end
-	feed_escape()
+	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
 	-- Highlight the yanked range
 	vim.defer_fn(function()
 		vim.highlight.range(bufnr, yank_ns, "IncSearch", { start_line - 1, 0 }, { end_line - 1, -1 })
@@ -139,17 +105,19 @@ end, { desc = "Yank file path, lines, and code (full lines)" })
 -- AI tools in tmux splits
 vim.g.ai_pane_id = nil
 local ai_pane_marker = "@nvim_ai_pane"
+local ai_pane_cmd_option = "@nvim_ai_cmd"
 
 local function tmux_available()
 	return vim.fn.executable("tmux") == 1
 end
 
 local function ai_pane_alive()
-	local target = ai_pane_target()
-	if not target then
+	if not vim.g.ai_pane_id then
 		return false
 	end
-	local check = vim.fn.system("tmux display-message -t " .. target .. " -p '#{pane_id}' 2>/dev/null")
+	local check = vim.fn.system(
+		"tmux display-message -t " .. vim.fn.shellescape(vim.g.ai_pane_id) .. " -p '#{pane_id}' 2>/dev/null"
+	)
 	return vim.trim(check) ~= ""
 end
 
@@ -165,20 +133,12 @@ local function tmux_set_pane_option(pane_id, option, value)
 	)
 end
 
-local function mark_ai_pane(pane_id)
+local function mark_ai_pane(pane_id, cmd)
 	if not pane_id or pane_id == "" then
 		return
 	end
 	tmux_set_pane_option(pane_id, ai_pane_marker, "1")
-end
-
-local function close_ai_pane()
-	local target = ai_pane_target()
-	if target then
-		vim.fn.system("tmux kill-pane -t " .. target)
-	end
-	vim.g.ai_pane_id = nil
-	print("AI pane closed")
+	tmux_set_pane_option(pane_id, ai_pane_cmd_option, cmd)
 end
 
 local ensure_ai_pane
@@ -199,8 +159,9 @@ end, { desc = "Send selection to AI pane" })
 
 -- Yank all file paths in Oil directory
 vim.keymap.set("n", "<leader>yo", function()
-	local oil = optional_require("oil", "Oil")
-	if not oil then
+	local ok, oil = pcall(require, "oil")
+	if not ok then
+		print("Oil not available")
 		return
 	end
 	local dir = oil.get_current_dir()
@@ -225,7 +186,9 @@ local function toggle_ai_split(cmd)
 		return
 	end
 	if ensure_ai_pane() then
-		close_ai_pane()
+		vim.fn.system("tmux kill-pane -t " .. vim.fn.shellescape(vim.g.ai_pane_id))
+		vim.g.ai_pane_id = nil
+		print("AI pane closed")
 		return
 	end
 	local pane_id = vim.fn.system(
@@ -240,20 +203,21 @@ local function toggle_ai_split(cmd)
 		print("Failed to create tmux split")
 		return
 	end
-	mark_ai_pane(pane_id)
+	mark_ai_pane(pane_id, cmd)
 	vim.g.ai_pane_id = pane_id
 end
 
-for _, mapping in ipairs({
-	{ lhs = "<leader>cc", cmd = "accd", desc = "Open Claude Code in tmux split" },
-	{ lhs = "<leader>cd", cmd = "acdd", desc = "Open Codex in tmux split" },
-	{ lhs = "<leader>co", cmd = "aco", desc = "Open OpenCode in tmux split" },
-}) do
-	local lhs, cmd, desc = mapping.lhs, mapping.cmd, mapping.desc
-	vim.keymap.set("n", lhs, function()
-		toggle_ai_split(cmd)
-	end, { desc = desc })
-end
+vim.keymap.set("n", "<leader>cc", function()
+	toggle_ai_split("accd")
+end, { desc = "Open Claude Code in tmux split" })
+
+vim.keymap.set("n", "<leader>cd", function()
+	toggle_ai_split("acdd")
+end, { desc = "Open Codex in tmux split" })
+
+vim.keymap.set("n", "<leader>co", function()
+	toggle_ai_split("aco")
+end, { desc = "Open OpenCode in tmux split" })
 
 vim.keymap.set("n", "<leader>cp", function()
 	if ensure_ai_pane() then
@@ -265,14 +229,16 @@ end, { desc = "Send file path to AI pane" })
 
 vim.keymap.set("n", "<leader>cq", function()
 	if ensure_ai_pane() then
-		close_ai_pane()
+		vim.fn.system("tmux kill-pane -t " .. vim.fn.shellescape(vim.g.ai_pane_id))
+		vim.g.ai_pane_id = nil
+		print("AI pane closed")
 	else
 		print("No AI pane open")
 	end
 end, { desc = "Close AI pane" })
 
 -- Find a pane this config marked, so it survives nvim closing and reopening.
-local function find_marked_ai_pane()
+local function find_ai_pane_in_window()
 	local out = vim.fn.system('tmux list-panes -F "#{pane_id}\t#{@nvim_ai_pane}" 2>/dev/null')
 	if vim.v.shell_error ~= 0 then
 		return nil
@@ -291,7 +257,7 @@ ensure_ai_pane = function()
 		return true
 	end
 
-	local existing = find_marked_ai_pane()
+	local existing = find_ai_pane_in_window()
 	if existing then
 		vim.g.ai_pane_id = existing
 		return true
@@ -328,8 +294,9 @@ vim.keymap.set("n", "<leader>cl", llm_jobs.open_list, { desc = "Open LLM job lis
 -- Quick scoped message: runs a one-shot editor task through cf_tool.
 vim.keymap.set("n", "<leader>cf", function()
 	local bufnr = vim.api.nvim_get_current_buf()
-	local file = current_file_or_notify()
-	if not file then
+	local file = vim.fn.expand("%:p")
+	if file == "" then
+		vim.notify("Current buffer has no file name", vim.log.levels.ERROR)
 		return
 	end
 	local line, snippet = cf_current_line_snippet()
@@ -344,14 +311,19 @@ end, { desc = "Run scoped LLM fix" })
 -- Visual mode: scoped message with line range
 vim.keymap.set("v", "<leader>cf", function()
 	local bufnr = vim.api.nvim_get_current_buf()
-	local start_line, end_line = visual_range()
-	local file = current_file_or_notify()
-	if not file then
-		feed_escape()
+	local start_line = vim.fn.line("v")
+	local end_line = vim.fn.line(".")
+	if start_line > end_line then
+		start_line, end_line = end_line, start_line
+	end
+	local file = vim.fn.expand("%:p")
+	if file == "" then
+		vim.notify("Current buffer has no file name", vim.log.levels.ERROR)
+		vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
 		return
 	end
 	local range = format_range(start_line, end_line)
-	feed_escape()
+	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
 
 	vim.schedule(function()
 		local message = vim.fn.input("LLM Message: ")

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -139,7 +139,6 @@ end, { desc = "Yank file path, lines, and code (full lines)" })
 -- AI tools in tmux splits
 vim.g.ai_pane_id = nil
 local ai_pane_marker = "@nvim_ai_pane"
-local ai_pane_cmd_option = "@nvim_ai_cmd"
 
 local function tmux_available()
 	return vim.fn.executable("tmux") == 1
@@ -166,12 +165,11 @@ local function tmux_set_pane_option(pane_id, option, value)
 	)
 end
 
-local function mark_ai_pane(pane_id, cmd)
+local function mark_ai_pane(pane_id)
 	if not pane_id or pane_id == "" then
 		return
 	end
 	tmux_set_pane_option(pane_id, ai_pane_marker, "1")
-	tmux_set_pane_option(pane_id, ai_pane_cmd_option, cmd)
 end
 
 local function close_ai_pane()
@@ -248,7 +246,7 @@ local function toggle_ai_split(cmd)
 		print("Failed to create tmux split")
 		return
 	end
-	mark_ai_pane(pane_id, cmd)
+	mark_ai_pane(pane_id)
 	vim.g.ai_pane_id = pane_id
 end
 
@@ -280,7 +278,7 @@ vim.keymap.set("n", "<leader>cq", function()
 end, { desc = "Close AI pane" })
 
 -- Find a pane this config marked, so it survives nvim closing and reopening.
-local function find_ai_pane_in_window()
+local function find_marked_ai_pane()
 	local out = vim.fn.system('tmux list-panes -F "#{pane_id}\t#{@nvim_ai_pane}" 2>/dev/null')
 	if vim.v.shell_error ~= 0 then
 		return nil
@@ -299,7 +297,7 @@ ensure_ai_pane = function()
 		return true
 	end
 
-	local existing = find_ai_pane_in_window()
+	local existing = find_marked_ai_pane()
 	if existing then
 		vim.g.ai_pane_id = existing
 		return true

--- a/lua/keymaps_ai.lua
+++ b/lua/keymaps_ai.lua
@@ -228,12 +228,19 @@ local function toggle_ai_split(cmd)
 		close_ai_pane()
 		return
 	end
-	local pane_id = vim.fn.system(
-		'tmux split-window -h -l 35% -P -F "#{pane_id}" -c '
-			.. vim.fn.shellescape(vim.fn.getcwd())
-			.. " "
-			.. vim.fn.shellescape("$SHELL -ic " .. vim.fn.shellescape(cmd))
-	)
+	local pane_id = vim.fn.system({
+		"tmux",
+		"split-window",
+		"-h",
+		"-l",
+		"35%",
+		"-P",
+		"-F",
+		"#{pane_id}",
+		"-c",
+		vim.fn.getcwd(),
+		"$SHELL -ic " .. vim.fn.shellescape(cmd),
+	})
 	pane_id = vim.trim(pane_id)
 	if pane_id == "" then
 		print("Failed to create tmux split")

--- a/lua/llm_jobs.lua
+++ b/lua/llm_jobs.lua
@@ -232,8 +232,10 @@ end
 local function start_log(job)
 	vim.fn.mkdir(jobs_dir, "p")
 
-	local command = vim.deepcopy(job.cmd)
-	command[#command] = "[prompt]"
+	local command = {}
+	for i, arg in ipairs(job.cmd) do
+		command[i] = arg == job.prompt and "[prompt]" or arg
+	end
 	local lines = {
 		"Job: " .. job.id,
 		"Tool: " .. job.tool,
@@ -290,6 +292,22 @@ end
 
 local function notify_job(job, status, level)
 	vim.notify(job.tool .. " " .. status .. "; <leader>cl for log", level)
+end
+
+local function completion_status(job, result)
+	if job.cancel_requested then
+		return "cancelled", "cancelled", vim.log.levels.WARN, false
+	end
+	if result.code == 124 then
+		return "timed out", "timed_out", vim.log.levels.ERROR, false
+	end
+	if result.signal and result.signal ~= 0 then
+		return "killed", "killed", vim.log.levels.ERROR, false
+	end
+	if result.code == 0 then
+		return "done", "done", nil, true
+	end
+	return "failed", "failed", vim.log.levels.ERROR, false
 end
 
 local function close_list()
@@ -727,29 +745,8 @@ function M.run(location, snippet, message, bufnr)
 			job.signal = result.signal
 			finish_log(job, result)
 
-			local status
-			local notify_level = vim.log.levels.ERROR
-			local checktime = false
-			if job.cancel_requested then
-				status = "cancelled"
-				job.status = "cancelled"
-				notify_level = vim.log.levels.WARN
-				job.cancelled = true
-			elseif result.code == 124 then
-				status = "timed out"
-				job.status = "timed_out"
-			elseif result.signal and result.signal ~= 0 then
-				status = "killed"
-				job.status = "killed"
-			elseif result.code == 0 then
-				status = "done"
-				job.status = "done"
-				notify_level = nil
-				checktime = true
-			else
-				status = "failed"
-				job.status = "failed"
-			end
+			local status, job_status, notify_level, checktime = completion_status(job, result)
+			job.status = job_status
 			update_activity_progress()
 			notify_job(job, status, notify_level)
 			if checktime then

--- a/lua/llm_jobs.lua
+++ b/lua/llm_jobs.lua
@@ -1,6 +1,5 @@
 local M = {}
 
-local timeout_ms = vim.g.cf_timeout_ms
 local log_dir = vim.fn.stdpath("cache") .. "/llm-exec"
 local jobs_dir = log_dir .. "/jobs"
 local jobs = {}
@@ -337,10 +336,29 @@ local function list_buf()
 	return buf
 end
 
+local function list_window_config()
+	local max_width = math.max(1, vim.o.columns - 4)
+	local max_height = math.max(1, vim.o.lines - 4)
+	local width = math.min(120, max_width, math.max(1, math.floor(vim.o.columns * 0.8)))
+	local height = math.min(24, max_height, math.max(1, math.floor(vim.o.lines * 0.55)))
+	return {
+		relative = "editor",
+		width = width,
+		height = height,
+		row = math.max(0, math.floor((vim.o.lines - height) / 2) - 1),
+		col = math.max(0, math.floor((vim.o.columns - width) / 2)),
+		style = "minimal",
+		border = "single",
+		title = " LLM jobs ",
+		title_pos = "center",
+	}
+end
+
 local render_list
 local render_log
 local open_job_log
 local refresh_current
+local readable_log
 
 local function safe_render_list()
 	if render_list then
@@ -452,11 +470,7 @@ open_job_log = function(job)
 	if not job then
 		return
 	end
-	if vim.fn.filereadable(job.log_path) ~= 1 then
-		if not job.log_missing_warned then
-			job.log_missing_warned = true
-			vim.notify("No log found for job #" .. job.id, vim.log.levels.WARN)
-		end
+	if not readable_log(job) then
 		return
 	end
 	if not list_state then
@@ -483,6 +497,21 @@ local function log_mtime(stat)
 	return tostring(stat.mtime.sec) .. "." .. tostring(stat.mtime.nsec or 0)
 end
 
+local function warn_missing_log(job)
+	if not job.log_missing_warned then
+		job.log_missing_warned = true
+		vim.notify("No log found for job #" .. job.id, vim.log.levels.WARN)
+	end
+end
+
+readable_log = function(job)
+	if vim.fn.filereadable(job.log_path) == 1 then
+		return true
+	end
+	warn_missing_log(job)
+	return false
+end
+
 local function read_log_delta(path, offset)
 	local file = io.open(path, "rb")
 	if not file then
@@ -507,6 +536,30 @@ local function append_log_lines(buf, text)
 	vim.bo[buf].modifiable = false
 end
 
+local function replace_log_lines(buf, job)
+	local lines = log_header(job)
+	vim.list_extend(lines, vim.fn.readfile(job.log_path))
+	set_lines(buf, lines)
+end
+
+local function update_log_cache(job, stat, mtime)
+	list_state.log_cache = {
+		job_id = job.id,
+		path = job.log_path,
+		size = stat.size,
+		mtime = mtime,
+	}
+end
+
+local function update_log_buffer(job, cache, can_append)
+	if can_append then
+		local delta = read_log_delta(job.log_path, cache.size)
+		append_log_lines(list_state.buf, delta)
+	else
+		replace_log_lines(list_state.buf, job)
+	end
+end
+
 render_log = function()
 	if not list_state or list_state.mode ~= "log" then
 		return
@@ -515,11 +568,7 @@ render_log = function()
 	if not job then
 		return
 	end
-	if vim.fn.filereadable(job.log_path) ~= 1 then
-		if not job.log_missing_warned then
-			job.log_missing_warned = true
-			vim.notify("No log found for job #" .. job.id, vim.log.levels.WARN)
-		end
+	if not readable_log(job) then
 		return
 	end
 	local stat = vim.uv.fs_stat(job.log_path)
@@ -544,20 +593,8 @@ render_log = function()
 		return
 	end
 
-	if can_append then
-		local delta = read_log_delta(job.log_path, cache.size)
-		append_log_lines(list_state.buf, delta)
-	else
-		local lines = log_header(job)
-		vim.list_extend(lines, vim.fn.readfile(job.log_path))
-		set_lines(list_state.buf, lines)
-	end
-	list_state.log_cache = {
-		job_id = job.id,
-		path = job.log_path,
-		size = stat.size,
-		mtime = mtime,
-	}
+	update_log_buffer(job, cache, can_append)
+	update_log_cache(job, stat, mtime)
 	if list_state.win and vim.api.nvim_win_is_valid(list_state.win) then
 		local max_row = math.max(1, vim.api.nvim_buf_line_count(list_state.buf))
 		local target_row = was_at_bottom and max_row or math.min(cursor_row, max_row)
@@ -588,29 +625,13 @@ end
 
 function M.open_list()
 	local buf = list_buf()
-	local max_width = math.max(1, vim.o.columns - 4)
-	local max_height = math.max(1, vim.o.lines - 4)
-	local width = math.min(120, max_width, math.max(1, math.floor(vim.o.columns * 0.8)))
-	local height = math.min(24, max_height, math.max(1, math.floor(vim.o.lines * 0.55)))
-	local row = math.max(0, math.floor((vim.o.lines - height) / 2) - 1)
-	local col = math.max(0, math.floor((vim.o.columns - width) / 2))
 	local win
 	local opened_new_win = false
 	if list_state and list_state.win and vim.api.nvim_win_is_valid(list_state.win) then
 		win = list_state.win
 		vim.api.nvim_set_current_win(win)
 	else
-		win = vim.api.nvim_open_win(buf, true, {
-			relative = "editor",
-			width = width,
-			height = height,
-			row = row,
-			col = col,
-			style = "minimal",
-			border = "single",
-			title = " LLM jobs ",
-			title_pos = "center",
-		})
+		win = vim.api.nvim_open_win(buf, true, list_window_config())
 		opened_new_win = true
 	end
 	vim.wo[win].wrap = false
@@ -695,6 +716,7 @@ function M.run(location, snippet, message, bufnr)
 	local file = vim.api.nvim_buf_get_name(bufnr)
 	local root = repo_root(file)
 	local prompt = build_prompt(location, snippet, message)
+	local timeout_ms = vim.g.cf_timeout_ms
 	local tool = current_tool()
 	if not tool then
 		return

--- a/lua/llm_jobs.lua
+++ b/lua/llm_jobs.lua
@@ -85,6 +85,15 @@ local function running_job_count()
 	return count
 end
 
+local function stop_activity_timer()
+	if not activity_timer then
+		return
+	end
+	activity_timer:stop()
+	activity_timer:close()
+	activity_timer = nil
+end
+
 local function start_activity_timer()
 	if activity_timer then
 		return
@@ -95,11 +104,7 @@ local function start_activity_timer()
 		150,
 		vim.schedule_wrap(function()
 			if (vim.g.llm_jobs_running or 0) == 0 then
-				if activity_timer then
-					activity_timer:stop()
-					activity_timer:close()
-					activity_timer = nil
-				end
+				stop_activity_timer()
 				return
 			end
 			vim.cmd("redrawstatus")
@@ -112,26 +117,11 @@ local function update_activity_progress()
 	vim.g.llm_jobs_running = count
 	vim.cmd("redrawstatus")
 	if count == 0 then
-		if activity_timer then
-			activity_timer:stop()
-			activity_timer:close()
-			activity_timer = nil
-		end
+		stop_activity_timer()
 		return
 	end
 
 	start_activity_timer()
-end
-
-local function append_lines(lines, text)
-	if not text or text == "" then
-		table.insert(lines, "(empty)")
-		return
-	end
-	text = tostring(text):gsub("\r\n", "\n"):gsub("\r", "\n")
-	for _, line in ipairs(vim.split(text, "\n", { plain = true })) do
-		table.insert(lines, line)
-	end
 end
 
 local function text_lines(text, opts)
@@ -150,6 +140,14 @@ local function text_lines(text, opts)
 		end
 	end
 	return lines
+end
+
+local function append_lines(lines, text)
+	if not text or text == "" then
+		table.insert(lines, "(empty)")
+		return
+	end
+	vim.list_extend(lines, text_lines(text))
 end
 
 local function normalize_lines(lines)
@@ -290,6 +288,10 @@ local function job_label(job)
 	return string.format("#%-3d %-10s %-6s %s %s", job.id, job.status, job.tool, format_elapsed(job), job.location)
 end
 
+local function notify_job(job, status, level)
+	vim.notify(job.tool .. " " .. status .. "; <leader>cl for log", level)
+end
+
 local function close_list()
 	if not list_state then
 		return
@@ -322,6 +324,12 @@ local render_log
 local open_job_log
 local refresh_current
 
+local function safe_render_list()
+	if render_list then
+		render_list()
+	end
+end
+
 local function cancel_job(job)
 	if not job then
 		return
@@ -337,9 +345,7 @@ local function cancel_job(job)
 	end
 	update_activity_progress()
 	vim.notify(job.tool .. " cancelling job #" .. job.id, vim.log.levels.WARN)
-	if render_list then
-		render_list()
-	end
+	safe_render_list()
 end
 
 local function selected_job()
@@ -545,7 +551,7 @@ refresh_current = function()
 	if list_state and list_state.mode == "log" then
 		render_log()
 	else
-		render_list()
+		safe_render_list()
 	end
 end
 
@@ -557,7 +563,7 @@ local function back_to_list()
 		list_state.mode = "list"
 		list_state.log_cache = nil
 		list_state.prefer_selected_job = true
-		render_list()
+		safe_render_list()
 		return
 	end
 end
@@ -633,7 +639,7 @@ function M.open_list()
 			end)
 		)
 	end
-	render_list()
+	safe_render_list()
 end
 
 local function write_buffer(bufnr)
@@ -701,9 +707,7 @@ function M.run(location, snippet, message, bufnr)
 	prune_jobs()
 	start_log(job)
 	update_activity_progress()
-	if render_list then
-		render_list()
-	end
+	safe_render_list()
 
 	local ok_system, handle = pcall(vim.system, cmd, {
 		cwd = root,
@@ -725,6 +729,7 @@ function M.run(location, snippet, message, bufnr)
 
 			local status
 			local notify_level = vim.log.levels.ERROR
+			local checktime = false
 			if job.cancel_requested then
 				status = "cancelled"
 				job.status = "cancelled"
@@ -737,23 +742,20 @@ function M.run(location, snippet, message, bufnr)
 				status = "killed"
 				job.status = "killed"
 			elseif result.code == 0 then
+				status = "done"
 				job.status = "done"
-				update_activity_progress()
-				vim.notify(job.tool .. " done; <leader>cl for log")
-				vim.cmd("checktime")
-				if render_list then
-					render_list()
-				end
-				return
+				notify_level = nil
+				checktime = true
 			else
 				status = "failed"
 				job.status = "failed"
 			end
 			update_activity_progress()
-			vim.notify(job.tool .. " " .. status .. "; <leader>cl for log", notify_level)
-			if render_list then
-				render_list()
+			notify_job(job, status, notify_level)
+			if checktime then
+				vim.cmd("checktime")
 			end
+			safe_render_list()
 		end)
 	end)
 
@@ -767,9 +769,7 @@ function M.run(location, snippet, message, bufnr)
 		}, job.log_path, "a")
 		update_activity_progress()
 		vim.notify("Failed to start " .. job.tool .. "; <leader>cl for log", vim.log.levels.ERROR)
-		if render_list then
-			render_list()
-		end
+		safe_render_list()
 		return
 	end
 	job.handle = handle


### PR DESCRIPTION
### Problem
The LLM keymap and job helpers had grown harder to reason about after adding scoped LLM execution, job logs, cancellation, and activity indicators.

### Changes
- Extracted shared helpers in `keymaps_ai.lua` for visual ranges, escaping visual mode, current-file guards, optional plugin requires, and AI pane targeting/closing.
- Table-driven the tmux AI split keymaps.
- Removed unused tmux pane command marker state.
- Renamed the marked pane lookup helper to better reflect what it does.
- Made LLM job timeout read dynamically inside `M.run`.
- Cleaned up LLM job activity timer, render-list calls, completion status handling, prompt redaction in logs, floating-window config, and log rendering helpers.

### Decisions
- Kept behavior intentionally unchanged where possible.
- Preserved the `$SHELL -ic <cmd>` tmux launch behavior so shell aliases like `accd`, `acdd`, and `aco` still resolve.
- Left larger module splitting out of scope.

### Testing
- Temporary Neovim Lua tests were created during implementation and deleted afterward.
- Tested keymap registrations, LLM job start/finish behavior, prompt redaction, completion status handling, dynamic timeout reads, and job list opening.
- Ran a headless Neovim config load.
- Ran `git diff --check`.

<details>
<summary>Agent Context</summary>

Original ask was to simplify the LLM/keymap files in `neovim-config` and inspect easy DRY opportunities and rough code. The work was done on `cleanup-llm-keymaps` from latest `main`.

Claude was asked for a second opinion on medium-risk cleanup. It agreed that prompt redaction by value was low risk, the tmux launch command cleanup had the highest real risk because aliases depend on shell behavior, and the completion state machine should only be simplified carefully. The implementation preserved `$SHELL -ic` and kept the human status label separate from the internal job status.

The main risk to test manually is tmux pane launch/reuse: `<leader>cc`, `<leader>cd`, and `<leader>co` should still open the right split, start the expected alias, toggle closed, and allow `<leader>cp` / visual `<leader>cx` to send text to the pane. Reopening Neovim in the same tmux window should still rediscover a marked pane.

Line count increased overall because helper extraction made responsibilities clearer rather than minimizing raw LOC.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI pane toggle reliably opens/closes the assistant pane, reports when none is open, and kills the correct target.
  * Visual-mode yank/fix commands exit visual mode safely and compute ranges reliably.
  * Job UI stops activity timers reliably and avoids missing or duplicated job logs.

* **Refactor**
  * Consolidated AI keymaps and simplified pane lifecycle handling.
  * Safer optional module loading with user notifications.
  * Cleaner, more reliable job log rendering and incremental updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryan-binazir/neovim-config/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->