### PR TITLE
refactor: isolate ai workflow modules

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -8,8 +8,6 @@ end
 dofile(local_config)
 
 local required_local_values = {
-	{ name = "cf_tool", kind = "string" },
-	{ name = "cf_timeout_ms", kind = "number" },
 	{ name = "obsidian_path", kind = "string" },
 	{ name = "supermaven_enabled", kind = "boolean" },
 }
@@ -21,13 +19,9 @@ for _, required in ipairs(required_local_values) do
 	end
 end
 
-if vim.g.cf_tool ~= "codex" and vim.g.cf_tool ~= "claude" then
-	error('local.lua must set vim.g.cf_tool to "codex" or "claude"')
-end
-
 require("options")
 require("keymaps_general")
-require("keymaps_ai")
+require("ai").setup(vim.g.ai or {})
 
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not vim.uv.fs_stat(lazypath) then

--- a/local.lua.example
+++ b/local.lua.example
@@ -1,5 +1,7 @@
-vim.g.cf_tool = "codex" -- "codex" or "claude"
-vim.g.cf_timeout_ms = 15 * 60 * 1000
+vim.g.ai = {
+	tool = "codex", -- "codex" or "claude"
+	timeout_ms = 15 * 60 * 1000,
+}
 vim.g.obsidian_path = "~/Obsidian/"
 vim.g.supermaven_enabled = false
 

--- a/lua/ai/config.lua
+++ b/lua/ai/config.lua
@@ -7,19 +7,19 @@ local defaults = {
 
 function M.resolve(opts)
 	opts = opts or vim.g.ai or {}
-	local config = vim.tbl_deep_extend("force", defaults, opts)
-
-	config.tool = opts.tool or vim.g.cf_tool or config.tool
-	config.timeout_ms = opts.timeout_ms or vim.g.cf_timeout_ms or config.timeout_ms
+	local config = {
+		tool = opts.tool or vim.g.cf_tool or defaults.tool,
+		timeout_ms = opts.timeout_ms or vim.g.cf_timeout_ms or defaults.timeout_ms,
+	}
 
 	if config.tool ~= "codex" and config.tool ~= "claude" then
-	error('vim.g.ai.tool must be "codex" or "claude"')
+		error('vim.g.ai.tool must be "codex" or "claude"')
 	end
 	if type(config.timeout_ms) ~= "number" then
-	error("vim.g.ai.timeout_ms must be a number")
+		error("vim.g.ai.timeout_ms must be a number")
 	end
 
 	return config
-	end
+end
 
-	return M
+return M

--- a/lua/ai/config.lua
+++ b/lua/ai/config.lua
@@ -1,0 +1,25 @@
+local M = {}
+
+local defaults = {
+	tool = "codex",
+	timeout_ms = 15 * 60 * 1000,
+}
+
+function M.resolve(opts)
+	opts = opts or vim.g.ai or {}
+	local config = vim.tbl_deep_extend("force", defaults, opts)
+
+	config.tool = opts.tool or vim.g.cf_tool or config.tool
+	config.timeout_ms = opts.timeout_ms or vim.g.cf_timeout_ms or config.timeout_ms
+
+	if config.tool ~= "codex" and config.tool ~= "claude" then
+	error('vim.g.ai.tool must be "codex" or "claude"')
+	end
+	if type(config.timeout_ms) ~= "number" then
+	error("vim.g.ai.timeout_ms must be a number")
+	end
+
+	return config
+	end
+
+	return M

--- a/lua/ai/config.lua
+++ b/lua/ai/config.lua
@@ -5,18 +5,28 @@ local defaults = {
 	timeout_ms = 15 * 60 * 1000,
 }
 
+local function optional_table(value, name)
+	if value == nil then
+		return nil
+	end
+	if type(value) ~= "table" then
+		error(name .. " must be a table")
+	end
+	return value
+end
+
 function M.resolve(opts)
-	opts = opts or vim.g.ai or {}
+	opts = optional_table(opts, "ai.setup opts") or optional_table(vim.g.ai, "vim.g.ai") or {}
 	local config = {
 		tool = opts.tool or vim.g.cf_tool or defaults.tool,
 		timeout_ms = opts.timeout_ms or vim.g.cf_timeout_ms or defaults.timeout_ms,
 	}
 
 	if config.tool ~= "codex" and config.tool ~= "claude" then
-		error('vim.g.ai.tool must be "codex" or "claude"')
+		error('invalid value for config.tool: ' .. tostring(config.tool) .. ' (expected "codex" or "claude")')
 	end
 	if type(config.timeout_ms) ~= "number" then
-		error("vim.g.ai.timeout_ms must be a number")
+		error("invalid value for config.timeout_ms: " .. tostring(config.timeout_ms) .. " (expected number)")
 	end
 
 	return config

--- a/lua/ai/init.lua
+++ b/lua/ai/init.lua
@@ -3,11 +3,11 @@ local M = {}
 function M.setup(opts)
 	local config = require("ai.config").resolve(opts)
 	require("ai.jobs").setup(config)
-	require("ai.keymaps").setup()
-	end
+	require("ai.keymaps")
+end
 
 function M.statusline_component()
 	return require("ai.jobs").statusline_component()
-	end
+end
 
-	return M
+return M

--- a/lua/ai/init.lua
+++ b/lua/ai/init.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+function M.setup(opts)
+	local config = require("ai.config").resolve(opts)
+	require("ai.jobs").setup(config)
+	require("ai.keymaps").setup()
+	end
+
+function M.statusline_component()
+	return require("ai.jobs").statusline_component()
+	end
+
+	return M

--- a/lua/ai/jobs.lua
+++ b/lua/ai/jobs.lua
@@ -8,11 +8,19 @@ local max_jobs = 50
 local max_log_files = 100
 local list_state = nil
 local activity_timer = nil
+local config = {
+	tool = "codex",
+	timeout_ms = 15 * 60 * 1000,
+}
+
+function M.setup(opts)
+	config = vim.tbl_deep_extend("force", config, opts or {})
+end
 
 local function current_tool()
-	local tool = vim.g.cf_tool
+	local tool = config.tool
 	if tool ~= "codex" and tool ~= "claude" then
-		vim.notify("Invalid vim.g.cf_tool: " .. tostring(tool), vim.log.levels.ERROR)
+		vim.notify("Invalid LLM tool: " .. tostring(tool), vim.log.levels.ERROR)
 		return nil
 	end
 	return tool
@@ -71,7 +79,7 @@ local function build_command(tool, root, prompt)
 			prompt,
 		}
 	end
-	return nil, "Unknown cf_tool: " .. tostring(tool)
+	return nil, "Unknown LLM tool: " .. tostring(tool)
 end
 
 local function running_job_count()
@@ -82,6 +90,20 @@ local function running_job_count()
 		end
 	end
 	return count
+end
+
+function M.running_count()
+	return running_job_count()
+end
+
+function M.statusline_component()
+	local running = running_job_count()
+	if running == 0 then
+		return ""
+	end
+	local frames = { "◐", "◓", "◑", "◒" }
+	local index = math.floor(vim.uv.now() / 150) % #frames + 1
+	return running > 1 and (frames[index] .. running) or frames[index]
 end
 
 local function stop_activity_timer()
@@ -102,7 +124,7 @@ local function start_activity_timer()
 		0,
 		150,
 		vim.schedule_wrap(function()
-			if (vim.g.llm_jobs_running or 0) == 0 then
+			if running_job_count() == 0 then
 				stop_activity_timer()
 				return
 			end
@@ -716,7 +738,7 @@ function M.run(location, snippet, message, bufnr)
 	local file = vim.api.nvim_buf_get_name(bufnr)
 	local root = repo_root(file)
 	local prompt = build_prompt(location, snippet, message)
-	local timeout_ms = vim.g.cf_timeout_ms
+	local timeout_ms = config.timeout_ms
 	local tool = current_tool()
 	if not tool then
 		return

--- a/lua/ai/jobs.lua
+++ b/lua/ai/jobs.lua
@@ -8,13 +8,14 @@ local max_jobs = 50
 local max_log_files = 100
 local list_state = nil
 local activity_timer = nil
-local config = {
+local default_config = {
 	tool = "codex",
 	timeout_ms = 15 * 60 * 1000,
 }
+local config = vim.deepcopy(default_config)
 
 function M.setup(opts)
-	config = vim.tbl_deep_extend("force", config, opts or {})
+	config = vim.tbl_deep_extend("force", vim.deepcopy(default_config), opts or {})
 end
 
 local function current_tool()

--- a/lua/ai/keymaps.lua
+++ b/lua/ai/keymaps.lua
@@ -288,7 +288,6 @@ local ai_split_commands = {
 		cmd = "codex --dangerously-bypass-approvals-and-sandbox",
 		desc = "Open Codex in tmux split",
 	},
-	{ lhs = "<leader>co", cmd = "opencode", desc = "Open OpenCode in tmux split" },
 }
 local default_ai_split_cmd = ai_split_commands[1].cmd
 

--- a/lua/ai/keymaps.lua
+++ b/lua/ai/keymaps.lua
@@ -31,6 +31,14 @@ local function current_file_or_notify()
 	return file
 end
 
+local function current_line_reference()
+	local file = current_file_or_notify()
+	if not file then
+		return nil
+	end
+	return file .. ":" .. vim.fn.line(".")
+end
+
 local function optional_require(name, label)
 	local ok, module = pcall(require, name)
 	if not ok then
@@ -285,6 +293,18 @@ local ai_split_commands = {
 local default_ai_split_cmd = ai_split_commands[1].cmd
 
 -- Send selection to AI pane
+vim.keymap.set("n", "<leader>cx", function()
+	local result = current_line_reference()
+	if not result then
+		return
+	end
+	if ensure_or_open_ai_pane(default_ai_split_cmd) then
+		send_to_ai_pane(result .. " ", true)
+	else
+		print("AI pane closed.")
+	end
+end, { desc = "Send current line to AI pane" })
+
 vim.keymap.set("v", "<leader>cx", function()
 	local result = yank_selection(false, true)
 	if ensure_or_open_ai_pane(default_ai_split_cmd) then

--- a/lua/ai/keymaps.lua
+++ b/lua/ai/keymaps.lua
@@ -1,4 +1,4 @@
--- AI workflow keymaps
+local M = {}
 
 -- Helper for yanking paths
 local function yank_paths(paths, label)
@@ -182,6 +182,8 @@ local function close_ai_pane()
 end
 
 local ensure_ai_pane
+local ensure_or_open_ai_pane
+local default_ai_split_cmd
 
 -- Send selection to AI pane
 vim.keymap.set("v", "<leader>cx", function()
@@ -190,7 +192,7 @@ vim.keymap.set("v", "<leader>cx", function()
 		return
 	end
 	local result = yank_selection(false, true)
-	if ensure_ai_pane() then
+	if ensure_or_open_ai_pane(default_ai_split_cmd) then
 		send_to_ai_pane(result .. " ", true)
 	else
 		print("AI pane closed.")
@@ -219,14 +221,10 @@ vim.keymap.set("n", "<leader>yo", function()
 	yank_paths(paths, "Oil paths")
 end, { desc = "Yank all file paths in Oil directory" })
 
-local function toggle_ai_split(cmd)
+local function open_ai_split(cmd)
 	if not tmux_available() then
 		print("tmux not available")
-		return
-	end
-	if ensure_ai_pane() then
-		close_ai_pane()
-		return
+		return false
 	end
 	local pane_id = vim.fn.system({
 		"tmux",
@@ -244,13 +242,33 @@ local function toggle_ai_split(cmd)
 	pane_id = vim.trim(pane_id)
 	if pane_id == "" then
 		print("Failed to create tmux split")
-		return
+		return false
 	end
 	mark_ai_pane(pane_id)
 	vim.g.ai_pane_id = pane_id
+	return true
 end
 
-for _, mapping in ipairs({
+local function toggle_ai_split(cmd)
+	if not tmux_available() then
+		print("tmux not available")
+		return
+	end
+	if ensure_ai_pane() then
+		close_ai_pane()
+		return
+	end
+	open_ai_split(cmd)
+end
+
+ensure_or_open_ai_pane = function(cmd)
+	if ensure_ai_pane() then
+		return true
+	end
+	return open_ai_split(cmd)
+end
+
+local ai_split_commands = {
 	{ lhs = "<leader>cc", cmd = "claude --dangerously-skip-permissions", desc = "Open Claude Code in tmux split" },
 	{
 		lhs = "<leader>cd",
@@ -258,7 +276,10 @@ for _, mapping in ipairs({
 		desc = "Open Codex in tmux split",
 	},
 	{ lhs = "<leader>co", cmd = "opencode", desc = "Open OpenCode in tmux split" },
-}) do
+}
+default_ai_split_cmd = ai_split_commands[1].cmd
+
+for _, mapping in ipairs(ai_split_commands) do
 	local lhs, cmd, desc = mapping.lhs, mapping.cmd, mapping.desc
 	vim.keymap.set("n", lhs, function()
 		toggle_ai_split(cmd)
@@ -266,10 +287,10 @@ for _, mapping in ipairs({
 end
 
 vim.keymap.set("n", "<leader>cp", function()
-	if ensure_ai_pane() then
+	if ensure_or_open_ai_pane(default_ai_split_cmd) then
 		send_to_ai_pane(vim.fn.expand("%:p") .. " ", true)
 	else
-		print("AI pane closed. Use <leader>cc to open.")
+		print("AI pane closed.")
 	end
 end, { desc = "Send file path to AI pane" })
 
@@ -310,7 +331,7 @@ ensure_ai_pane = function()
 	return false
 end
 
-local llm_jobs = require("llm_jobs")
+local llm_jobs = require("ai.jobs")
 
 local function llm_location_label(file, range)
 	return (file .. ":" .. range):gsub("%c", " ")
@@ -335,7 +356,7 @@ end
 
 vim.keymap.set("n", "<leader>cl", llm_jobs.open_list, { desc = "Open LLM job list" })
 
--- Quick scoped message: runs a one-shot editor task through cf_tool.
+-- Quick scoped message: runs a one-shot editor task through the configured LLM tool.
 vim.keymap.set("n", "<leader>cf", function()
 	local bufnr = vim.api.nvim_get_current_buf()
 	local file = current_file_or_notify()
@@ -372,3 +393,7 @@ vim.keymap.set("v", "<leader>cf", function()
 		llm_jobs.run(llm_location_label(file, range), snippet, message, bufnr)
 	end)
 end, { desc = "Run scoped LLM fix with selection" })
+
+function M.setup() end
+
+return M

--- a/lua/ai/keymaps.lua
+++ b/lua/ai/keymaps.lua
@@ -1,5 +1,3 @@
-local M = {}
-
 -- Helper for yanking paths
 local function yank_paths(paths, label)
 	vim.fn.setreg("+", table.concat(paths, "\n"))
@@ -181,23 +179,34 @@ local function close_ai_pane()
 	print("AI pane closed")
 end
 
-local ensure_ai_pane
-local ensure_or_open_ai_pane
-local default_ai_split_cmd
+-- Find a pane this config marked, so it survives nvim closing and reopening.
+local function find_marked_ai_pane()
+	local out = vim.fn.system('tmux list-panes -F "#{pane_id}\t#{@nvim_ai_pane}" 2>/dev/null')
+	if vim.v.shell_error ~= 0 then
+		return nil
+	end
+	for _, line in ipairs(vim.split(vim.trim(out), "\n", { trimempty = true })) do
+		local parts = vim.split(line, "\t", { plain = true })
+		if parts[2] == "1" and parts[1] and parts[1] ~= "" then
+			return parts[1]
+		end
+	end
+	return nil
+end
 
--- Send selection to AI pane
-vim.keymap.set("v", "<leader>cx", function()
-	if not tmux_available() then
-		print("tmux not available")
-		return
+local function ensure_ai_pane()
+	if ai_pane_alive() then
+		return true
 	end
-	local result = yank_selection(false, true)
-	if ensure_or_open_ai_pane(default_ai_split_cmd) then
-		send_to_ai_pane(result .. " ", true)
-	else
-		print("AI pane closed.")
+
+	local existing = find_marked_ai_pane()
+	if existing then
+		vim.g.ai_pane_id = existing
+		return true
 	end
-end, { desc = "Send selection to AI pane" })
+
+	return false
+end
 
 -- Yank all file paths in Oil directory
 vim.keymap.set("n", "<leader>yo", function()
@@ -250,10 +259,6 @@ local function open_ai_split(cmd)
 end
 
 local function toggle_ai_split(cmd)
-	if not tmux_available() then
-		print("tmux not available")
-		return
-	end
 	if ensure_ai_pane() then
 		close_ai_pane()
 		return
@@ -261,7 +266,7 @@ local function toggle_ai_split(cmd)
 	open_ai_split(cmd)
 end
 
-ensure_or_open_ai_pane = function(cmd)
+local function ensure_or_open_ai_pane(cmd)
 	if ensure_ai_pane() then
 		return true
 	end
@@ -277,7 +282,17 @@ local ai_split_commands = {
 	},
 	{ lhs = "<leader>co", cmd = "opencode", desc = "Open OpenCode in tmux split" },
 }
-default_ai_split_cmd = ai_split_commands[1].cmd
+local default_ai_split_cmd = ai_split_commands[1].cmd
+
+-- Send selection to AI pane
+vim.keymap.set("v", "<leader>cx", function()
+	local result = yank_selection(false, true)
+	if ensure_or_open_ai_pane(default_ai_split_cmd) then
+		send_to_ai_pane(result .. " ", true)
+	else
+		print("AI pane closed.")
+	end
+end, { desc = "Send selection to AI pane" })
 
 for _, mapping in ipairs(ai_split_commands) do
 	local lhs, cmd, desc = mapping.lhs, mapping.cmd, mapping.desc
@@ -301,35 +316,6 @@ vim.keymap.set("n", "<leader>cq", function()
 		print("No AI pane open")
 	end
 end, { desc = "Close AI pane" })
-
--- Find a pane this config marked, so it survives nvim closing and reopening.
-local function find_marked_ai_pane()
-	local out = vim.fn.system('tmux list-panes -F "#{pane_id}\t#{@nvim_ai_pane}" 2>/dev/null')
-	if vim.v.shell_error ~= 0 then
-		return nil
-	end
-	for _, line in ipairs(vim.split(vim.trim(out), "\n", { trimempty = true })) do
-		local parts = vim.split(line, "\t", { plain = true })
-		if parts[2] == "1" and parts[1] and parts[1] ~= "" then
-			return parts[1]
-		end
-	end
-	return nil
-end
-
-ensure_ai_pane = function()
-	if ai_pane_alive() then
-		return true
-	end
-
-	local existing = find_marked_ai_pane()
-	if existing then
-		vim.g.ai_pane_id = existing
-		return true
-	end
-
-	return false
-end
 
 local llm_jobs = require("ai.jobs")
 
@@ -393,7 +379,3 @@ vim.keymap.set("v", "<leader>cf", function()
 		llm_jobs.run(llm_location_label(file, range), snippet, message, bufnr)
 	end)
 end, { desc = "Run scoped LLM fix with selection" })
-
-function M.setup() end
-
-return M

--- a/lua/plugins/ai.lua
+++ b/lua/plugins/ai.lua
@@ -20,14 +20,6 @@ return {
 			})
 
 			local api = require("supermaven-nvim.api")
-			vim.api.nvim_create_autocmd("VimEnter", {
-				callback = function()
-					vim.defer_fn(function()
-						api.start()
-					end, 100)
-				end,
-			})
-
 			vim.keymap.set("n", "<leader>sm", function()
 				if api.is_running() then
 					api.stop()

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -81,13 +81,8 @@ return {
 					"diff",
 					"diagnostics",
 					function()
-						local running = vim.g.llm_jobs_running or 0
-						if running == 0 then
-							return ""
-						end
-						local frames = { "◐", "◓", "◑", "◒" }
-						local index = math.floor(vim.uv.now() / 150) % #frames + 1
-						return running > 1 and (frames[index] .. running) or frames[index]
+						local ok, ai = pcall(require, "ai")
+						return ok and ai.statusline_component() or ""
 					end,
 				},
 				lualine_c = { "filename" },


### PR DESCRIPTION
### Problem

The local Neovim AI workflow was wired through top-level `keymaps_ai` / `llm_jobs` modules, making it harder to see the workflow as one local subsystem. Two behavior edges also needed cleanup: Supermaven was manually started even when enabled, and `<leader>cp` / `<leader>cx` bailed when the AI side pane was closed.

### Changes

- Move the local AI workflow under `lua/ai/` with `config`, `init`, `jobs`, and `keymaps` modules.
- Route startup through `require("ai").setup(vim.g.ai or {})`.
- Add `vim.g.ai.tool` / `vim.g.ai.timeout_ms` config with legacy `vim.g.cf_tool` / `vim.g.cf_timeout_ms` fallback.
- Expose the LLM job statusline component through the AI module.
- Stop manually starting Supermaven on `VimEnter`.
- Make `<leader>cp`, normal `<leader>cx`, and visual `<leader>cx` open the default Claude Code side pane before sending when no pane is open.
- Add normal-mode `<leader>cx` to send the current file and cursor line to the AI pane.

### Decisions

- Keep this as a local config namespace, not a plugin.
- Keep the first pass close to the existing implementation rather than fully splitting tmux/context helpers.
- Preserve existing keymaps and user-facing workflow outside the requested side-pane send behavior changes.

### Testing

- `nvim --headless -u NONE '+set rtp^=.' '+lua vim.g.ai = { tool = "codex", timeout_ms = 1000 }; require("ai").setup(); local keys = { {"<leader>cp", "n"}, {"<leader>cx", "v"}, {"<leader>cf", "n"}, {"<leader>cl", "n"} }; for _, key in ipairs(keys) do local m = vim.fn.maparg(key[1], key[2], false, true); if not m or not m.callback then error("missing keymap " .. key[1]) end end; local status = require("ai").statusline_component(); if status ~= "" then error("unexpected statusline: " .. status) end' '+qa'`
- `nvim --headless -u NONE '+set rtp^=.' '+lua vim.g.cf_tool = "claude"; vim.g.cf_timeout_ms = 1234; local config = require("ai.config").resolve({}); if config.tool ~= "claude" or config.timeout_ms ~= 1234 then error("legacy config fallback failed") end' '+qa'`
- `cp local.lua.example local.lua && nvim --headless '+qa' ; rc=$?; rm -f local.lua; exit $rc`
- Mocked `<leader>cp` and normal `<leader>cx` with `vim.fn.system` / `vim.fn.executable` to verify they call `tmux split-window` before `tmux send-keys` when no pane is open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Consolidated AI tool and timeout into a single AI config with defaults, validation, and legacy globals removed.

* **New Features**
  * Added AI setup entry point to initialize AI services when configured.
  * Added animated AI jobs status indicator for the statusline and a running-job count helper.

* **Changes**
  * AI pane/split keybindings now ensure-or-open an AI pane and support pane reattachment across restarts.
  * Supermaven now requires manual activation via <leader>sm.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryan-binazir/neovim-config/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->